### PR TITLE
🚧  アカウント登録後にメインMenuに戻るようにしました

### DIFF
--- a/randuraft_web_app/lib/register/registration_page.dart
+++ b/randuraft_web_app/lib/register/registration_page.dart
@@ -34,6 +34,9 @@ class _RegistrationPageState extends State<RegistrationPage> {
         scaffoldMessenger.showSnackBar(
           const SnackBar(content: Text('Successfully Registered!')),
         );
+        if (!mounted) return;
+        // /HomePage に移動
+        Navigator.of(context).popUntil((route) => route.isFirst);
       } catch (e) {
         debugPrint("Registration failed with error: $e");
         scaffoldMessenger.showSnackBar(


### PR DESCRIPTION
アカウント登録したら，HomePage (最初のメイン画面)に自動遷移するようにしました．
この時，ルーティングのスタックを破棄して，LoginPageやRegistrationPageに戻れないようにしています．

パスルーティングを実装すれば，スタックのHomePageだけ残して，UserModelPageに自動遷移することもできそうですが，ほぼ全てのルーティングの処理を書き直しになりそうなので，とりあえずはこれで提出いたします．