### PR TITLE
.envが読み込めない問題を解決

### DIFF
--- a/randuraft_web_app/pubspec.yaml
+++ b/randuraft_web_app/pubspec.yaml
@@ -39,4 +39,5 @@ dev_dependencies:
 flutter:
   assets:
     - assets/images/
+    - .env
   uses-material-design: true


### PR DESCRIPTION
<!-- NotionのチケットにPRを紐づけてください -->
### 説明

pubspec.yamlのassets項目に.envを追加することで、この問題を解決しました。
これによって、今まで通り、ルートディレクトリに.envを記載した状態でビルドが可能になります

### 関連するIssue
- #98 

### 動作再現方法・スクリーンショット
- [Issueを参照](https://github.com/gilmiwired/randuraft/issues/98#issuecomment-2129181394)

## その他
- 横山と寺沢はこの方法で解決しました